### PR TITLE
refcator vtv and message state

### DIFF
--- a/components/AppView.jsx
+++ b/components/AppView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Head from './Head'
 import Nav from './Nav'
 import { ChannelView, getTheme } from '@resources/console'
@@ -16,26 +16,32 @@ const infoForDevices = {
 }
 
 const AppView = ({ popup, selectedTheme, onThemeChange, store }) => {
+  const mounted = useRef()
   const [device, setDevice] = useState('default')
   const [keyboardOpen, setKeyboardOpen] = useState(false)
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const iOS =
-        /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream
-      if (iOS) {
-        setDevice('ios')
+    if (mounted.current) {
+      if (typeof window !== 'undefined') {
+        const iOS =
+          /iPad|iPhone|iPod/.test(window.navigator.userAgent) &&
+          !window.MSStream
+        if (iOS) {
+          setDevice('ios')
+        }
       }
     }
   })
 
   const handleFocusChange = focus => {
-    setKeyboardOpen(focus)
-    setTimeout(() => {
-      if (device === 'ios' && typeof window !== 'undefined') {
-        window.document.body.scrollTop = 0
-      }
-    }, 30)
+    if (mounted.current) {
+      setKeyboardOpen(focus)
+      setTimeout(() => {
+        if (device === 'ios' && typeof window !== 'undefined') {
+          window.document.body.scrollTop = 0
+        }
+      }, 30)
+    }
   }
 
   const theme = getTheme(selectedTheme)
@@ -44,8 +50,8 @@ const AppView = ({ popup, selectedTheme, onThemeChange, store }) => {
     deviceInfo.toolbarHeight + (keyboardOpen ? deviceInfo.keyboardHeight : 0)
 
   return (
-    <div>
-      <Head title="Home" />
+    <div ref={mounted}>
+      <Head title="Resources.co" />
       <ChannelView
         navComponent={Nav}
         onFocusChange={handleFocusChange}

--- a/packages/console/src/components/messages/Message.jsx
+++ b/packages/console/src/components/messages/Message.jsx
@@ -9,12 +9,6 @@ import { faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 export default ({ type, code, text, url, content, theme, ...props }) => {
-  const [loaded, setLoaded] = useState(false)
-  const handleLoaded = () => {
-    const { onLoad } = props
-    setLoaded(true)
-    onLoad()
-  }
   if (type === 'tree') {
     const {
       name,
@@ -133,14 +127,8 @@ export default ({ type, code, text, url, content, theme, ...props }) => {
       </div>
     )
   } else if (type === 'image') {
-    const imageStyle = loaded ? { maxHeight: '50vh' } : { height: '50vh' }
-    return (
-      <img
-        src={url}
-        style={{ ...imageStyle, margin: 5 }}
-        onLoad={() => setTimeout(handleLoaded, 10)}
-      />
-    )
+    const imageStyle = { maxHeight: '50vh' }
+    return <img src={url} style={{ ...imageStyle, margin: 5 }} />
   } else if (type === 'data') {
     const { data, keyField, title, link, pickPrefix, onPickId } = props
     return (

--- a/packages/vtv/src/index.js
+++ b/packages/vtv/src/index.js
@@ -1,6 +1,12 @@
 import View from './View'
 export { default as Textarea } from './generic/Textarea'
-export { getPaths, splitPath, joinPath, parseCommand } from './model'
-export { updateTree } from './model/state'
+export {
+  getPaths,
+  splitPath,
+  joinPath,
+  parseCommand,
+  removeTemporaryState,
+  updateTree,
+} from './model'
 
 export default View

--- a/packages/vtv/src/model/actions/index.js
+++ b/packages/vtv/src/model/actions/index.js
@@ -1,0 +1,1 @@
+export { default as rename } from './rename'

--- a/packages/vtv/src/model/actions/rename.js
+++ b/packages/vtv/src/model/actions/rename.js
@@ -1,0 +1,27 @@
+import produce from 'immer'
+import { getStateKey, draftValue, draftState, renameDraftKey } from '../util'
+
+export default function rename(treeData, treeUpdate) {
+  return produce(treeData, draft => {
+    draftState(draft, treeUpdate.path)._editingName = treeUpdate.editing
+    if (typeof treeUpdate.value !== 'undefined') {
+      if (treeUpdate.path.length === 0) {
+        draft.name = treeUpdate.value
+      } else if (
+        treeUpdate.path[treeUpdate.path.length - 1] !== treeUpdate.value
+      ) {
+        const lastIndex = treeUpdate.path.length - 1
+        const parentPath = treeUpdate.path.slice(0, lastIndex)
+        const key = treeUpdate.path[lastIndex]
+        const draftParentValue = draftValue(draft, parentPath)
+
+        renameDraftKey(draftParentValue, key, treeUpdate.value)
+
+        const draftParentState = draftState(draft, parentPath)
+        draftParentState[getStateKey(treeUpdate.value)] =
+          draftParentState[getStateKey(key)]
+        delete draftParentState[getStateKey(key)]
+      }
+    }
+  })
+}

--- a/packages/vtv/src/model/index.js
+++ b/packages/vtv/src/model/index.js
@@ -1,2 +1,3 @@
 export { getPaths, splitPath, joinPath } from './analyze'
 export { parseCommand } from './parse'
+export { updateTree, removeTemporaryState } from './state'

--- a/packages/vtv/src/model/util/draftState.js
+++ b/packages/vtv/src/model/util/draftState.js
@@ -1,0 +1,11 @@
+import getStateKey from './getStateKey'
+
+export default function draftState(draft, path) {
+  let draftState = draft.state
+  for (let key of path) {
+    const stateKey = getStateKey(key)
+    draftState[stateKey] = draftState[stateKey] || {}
+    draftState = draftState[stateKey]
+  }
+  return draftState
+}

--- a/packages/vtv/src/model/util/draftValue.js
+++ b/packages/vtv/src/model/util/draftValue.js
@@ -1,0 +1,7 @@
+export default function draftValue(draft, path) {
+  let draftValue = draft.value
+  for (let key of path) {
+    draftValue = draftValue[key]
+  }
+  return draftValue
+}

--- a/packages/vtv/src/model/util/getStateKey.js
+++ b/packages/vtv/src/model/util/getStateKey.js
@@ -1,0 +1,3 @@
+export default function getStateKey(key) {
+  return typeof key === 'string' ? (key.startsWith('_') ? `_${key}` : key) : key
+}

--- a/packages/vtv/src/model/util/index.js
+++ b/packages/vtv/src/model/util/index.js
@@ -1,0 +1,4 @@
+export { default as getStateKey } from './getStateKey'
+export { default as draftState } from './draftState'
+export { default as draftValue } from './draftValue'
+export { default as renameDraftKey } from './renameDraftKey'

--- a/packages/vtv/src/model/util/renameDraftKey.js
+++ b/packages/vtv/src/model/util/renameDraftKey.js
@@ -1,0 +1,22 @@
+// rename the key in a draft while preserving order
+export default function renameDraftKey(draftParentValue, key, newKey) {
+  const keys = Object.keys(draftParentValue)
+  const keysToAppend = keys.slice(keys.indexOf(key) + 1)
+  const valuesToAppend = []
+
+  // save and remove all key/value pairs after the old key name
+  for (let key of keysToAppend) {
+    valuesToAppend.push(draftParentValue[key])
+    delete draftParentValue[key]
+  }
+
+  // rename the key
+  const newValue = draftParentValue[key]
+  delete draftParentValue[key]
+  draftParentValue[newKey] = newValue
+
+  // add all the saved key/value pairs back
+  for (let i = 0; i < keysToAppend.length; i++) {
+    draftParentValue[keysToAppend[i]] = valuesToAppend[i]
+  }
+}

--- a/packages/vtv/src/tree/NodeValueView.jsx
+++ b/packages/vtv/src/tree/NodeValueView.jsx
@@ -6,8 +6,10 @@ import Link from '../value/Link'
 import StringView from '../value/StringView'
 import CollectionSummary from '../value/CollectionSummary'
 
-const inputValue = value => {
-  if (typeof value === 'string') {
+const inputValue = (value, isNew = false) => {
+  if (isNew && value === null) {
+    return ''
+  } else if (typeof value === 'string') {
     if (/^\s*$/.test(value) || /\n|\t/.test(value)) {
       return JSON.stringify(value)
     }
@@ -30,11 +32,12 @@ const InlineValue = ({
   onMessage,
   editing,
   editingJson,
+  isNew,
   autoEdit,
   theme,
 }) => {
   const inputRef = useRef()
-  const [newInputValue, setNewInputValue] = useState(inputValue(value))
+  const [newInputValue, setNewInputValue] = useState(inputValue(value, isNew))
   useEffect(() => {
     setNewInputValue(inputValue(value))
   }, [editingJson])
@@ -50,12 +53,17 @@ const InlineValue = ({
   }, [editing, inputRef])
 
   const sendAction = (data = {}) => {}
-
-  let newValue, parsed
-  try {
-    newValue = JSON.parse(newInputValue)
-  } catch (e) {
-    newValue = newInputValue
+  let newValue
+  let parsed = false
+  if (newInputValue === '') {
+    newValue = null
+  } else {
+    try {
+      newValue = JSON.parse(newInputValue)
+      parsed = true
+    } catch (e) {
+      newValue = newInputValue
+    }
   }
 
   const save = () => {
@@ -152,7 +160,11 @@ export default ({
   autoEdit = true,
   theme,
 }) => {
-  const { _editing: editing, _editingJson: editingJson } = getState(state)
+  const {
+    _editing: editing,
+    _editingJson: editingJson,
+    _isNew: isNew,
+  } = getState(state)
   if (editing) {
     return (
       <InlineValue
@@ -168,38 +180,22 @@ export default ({
       />
     )
   } else {
-    if (typeof value === 'string') {
-      if (detectUrl(value)) {
-        const handleEdit = () => {
-          onMessage({
-            path,
-            action: 'edit',
-            editing: true,
-          })
-        }
-        return (
-          <Link
-            url={value}
-            onEdit={handleEdit}
-            onPickId={onPickId}
-            theme={theme}
-          />
-        )
-      } else {
-        return (
-          <InlineValue
-            name={name}
-            value={value}
-            state={state}
-            path={path}
-            onMessage={onMessage}
-            editing={editing}
-            editingJson={editingJson}
-            autoEdit={autoEdit}
-            theme={theme}
-          />
-        )
+    if (typeof value === 'string' && detectUrl(value)) {
+      const handleEdit = () => {
+        onMessage({
+          path,
+          action: 'edit',
+          editing: true,
+        })
       }
+      return (
+        <Link
+          url={value}
+          onEdit={handleEdit}
+          onPickId={onPickId}
+          theme={theme}
+        />
+      )
     } else if (typeof value === 'object' && value !== null) {
       return (
         <CollectionSummary
@@ -218,6 +214,7 @@ export default ({
           onMessage={onMessage}
           editing={editing}
           editingJson={editingJson}
+          isNew={isNew}
           autoEdit={autoEdit}
           theme={theme}
         />


### PR DESCRIPTION
- begin breaking vtv state into files
- fix a performance issue where typing text into the console would trigger a re-render of all the messages
- make it so when you un-focus a value in vtv with it empty, it sets the value to null rather than an empty string (set to empty quotes for an empty string)